### PR TITLE
[Feature] 1.0.0 Release prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 
 Toaster is a Toast library built for and in SwiftUI for iOS, macOS, and tvOS that allows you to quickly add customizable **WCAG 2.1 compliant** toast functionality to your SwiftUI project with minimal code.
 
+Toaster has some great features that allow for seamless integration in your app:
+
+- Color customization - To match your app's theme
+- WCAG 2.1 compliance - Accessibility out of the box
+- Haptics (iOS 17+) - Sensory feedback based on toast type
+- Custom duration - Display for as long (or short as you like)
+
 ![Types of toasts on light and dark backgrounds](https://user-images.githubusercontent.com/10408147/212543513-d07445b0-9d45-4451-ab2c-40e1d9fb4965.jpg)
 
 ## Installing Toaster
@@ -23,7 +30,7 @@ To install Toaster using  [Swift Package Manager](https://github.com/apple/swift
 or you can add the following dependency to your  `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/glowcap/toaster.git", from: "0.5.0")
+.package(url: "https://github.com/glowcap/toaster.git", from: "1.0.0")
 ```
 
 ### CocoaPods
@@ -31,7 +38,7 @@ or you can add the following dependency to your  `Package.swift`:
 Add the pod to your Podfile:
 
 ```ruby
-pod 'Toaster', :git => 'https://github.com/glowcap/Toaster', :tag => 'v0.5.0'
+pod 'Toaster', :git => 'https://github.com/glowcap/Toaster', :tag => 'v1.0.0'
 ```
 
 And then run:
@@ -117,10 +124,10 @@ In accordance with  WCAG guideline  [3.2.4](https://www.w3.org/TR/UNDERSTANDING-
 
 | ToastType  | Screen Reader Prefix |
 |------------|----------------------|
-| error      | error,               |
-| info       | information,         |
-| success    | success,             |
-| warning    | warning,             |
+| error      | error                |
+| info       | information          |
+| success    | success              |
+| warning    | warning              |
 
 <br>
 
@@ -133,11 +140,8 @@ The close button has the alt-text of `close`
 
 Toast focus order is:
 
- 1. Title
- 2. Message
+ 1. Content
  3. Close Button
-
-> ☝️ Since the Toast Icon is decorative and the screenreader title is prefixed with the Toast Type, the icon is hidden from screen readers.
 
 <br>
 
@@ -163,14 +167,6 @@ This is also handled almost natively by SwiftUI's font types. However, The lengt
 
 <br> 
 
-**Guideline 9 (_under development_):**  **Announcing toast message content without focus**
-
-New to WCAG 2.1, satisfying  [Guideline 4.1.3](https://www.w3.org/TR/WCAG21/#status-messages)  requires that:
-
-In content implemented using markup languages, status messages can be programmatically determined through role or properties such that they can be presented to the user by assistive technologies without receiving focus.
-
-👷🏽‍♂️ _This feature is still under development. Currently, Toasts will block the window interaction (besides the toast) while the toast is displayed, and allows the next user focus to be the toast_
-
 ## Data Collection
 
 Toaster does not collect any data. This notice is provided to help you fill out  [App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/).
@@ -180,3 +176,4 @@ Toaster does not collect any data. This notice is provided to help you fill out 
 Contributions are always appreciated! To make changes to the project, you can fork the repo and open `ToastDemo.xcworkspace`. This workspace includes:
 
  - the Toaster package (for iOS, macOS, and tvOS)
+

--- a/Sources/Toaster/Modifiers/SensoryFeedbackModifier.swift
+++ b/Sources/Toaster/Modifiers/SensoryFeedbackModifier.swift
@@ -1,0 +1,46 @@
+//
+//  SensoryFeedbackModifier.swift
+//  Toaster
+//
+//  Created by Daymein Gregorio on 10/4/25.
+//
+
+import SwiftUI
+
+private struct SensoryFeedbackModifier: ViewModifier {
+
+  @Binding var toast: Toaster?
+
+  /// Sensory feedback type based on toast type.
+  /// - Note: Available for iOS 17+.
+  @available(iOS 17.0, *)
+  var feedback: SensoryFeedback {
+    switch toast?.type {
+    case .warning: .warning
+    case .error: .error
+    default: .success
+    }
+  }
+
+  func body(content: Content) -> some View {
+    if #available(iOS 17.0, *) {
+      content
+        .sensoryFeedback(feedback, trigger: toast) { _, newValue in
+          newValue != nil
+        }
+    } else {
+      content
+    }
+  }
+
+}
+
+extension View {
+
+  /// Adds sensory feedback for users running iOS 17+.
+  /// - Parameter toast: Toast.
+  /// - Returns: Returns sensory feeback if available to user.
+  func sensoryFeedback(_ toast: Binding<Toaster?>) -> some View {
+      modifier(SensoryFeedbackModifier(toast: toast))
+  }
+}

--- a/Sources/Toaster/Modifiers/ToasterModifier.swift
+++ b/Sources/Toaster/Modifiers/ToasterModifier.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 struct ToasterModifier: ViewModifier {
   
-  /// toast content to be shown
+  /// Toast content to be shown.
   @Binding var toast: Toaster?
-  
-  /// needed to dismiss on tap
+
+  /// needed to dismiss on tap.
   @State private var workItem: DispatchWorkItem?
-  
+
+  /// Vertical drag gesture amount.
+  @State private var verticalDragAmount: CGFloat = .zero
+
   func body(content: Content) -> some View {
     content
       .accessibilityHidden(toast != nil)
@@ -35,35 +38,58 @@ struct ToasterModifier: ViewModifier {
           .allowsHitTesting(false)
       }
       toasterView()
-        .offset(y: -30)
+        .offset(y: -30 + verticalDragAmount)
         .accessibilitySortPriority(1000)
-    }.animation(.spring(), value: toast)
+        .gesture(
+          DragGesture(coordinateSpace: .local)
+            .onChanged(handleDragChanged)
+            .onEnded(handleDragEnded)
+        )
+    }
+    .animation(.spring, value: toast)
     .accessibilityElement(children: .contain)
   }
 
   @ViewBuilder private func toasterView() -> some View {
     if let toast = toast {
       VStack {
-        Spacer()
-          .allowsHitTesting(false)
         ToasterView(
           type: toast.type,
           title: toast.title,
           message: toast.message)
         { dismissToast() }
       }
+      .frame(maxHeight: .infinity, alignment: .bottom)
       .transition(.move(edge: .bottom))
     }
   }
   
+  /// Handles drag changes while drag is active.
+  /// - Parameter drag: Drag value.
+  private func handleDragChanged(_ drag: DragGesture.Value) {
+    let dragHeight = drag.translation.height
+    // ignore drags that would move the toast up
+    guard dragHeight > 0 else { return }
+    verticalDragAmount = dragHeight
+  }
+  
+  /// Handles end of drag.
+  /// - Parameter drag: Drag value
+  private func handleDragEnded(_ drag: DragGesture.Value) {
+    withAnimation(.smooth) {
+      if drag.translation.height > 80 {
+        dismissToast()
+      }
+      // always reset the drag amount
+      verticalDragAmount = .zero
+    }
+  }
+
   /// Tracks toast's life cycle
   private func trackToast() {
-    guard let toast else { return }
-  
-    /// adds tactile feedback to notify the user that a toast is being displayed
-    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-    
-    guard toast.duration > 0 else { return }
+    guard let toast,
+          toast.duration > 0
+    else { return }
     workItem = DispatchWorkItem { dismissToast() }
     DispatchQueue.main
       .asyncAfter(deadline: .now() + toast.duration, execute: workItem!)
@@ -94,7 +120,8 @@ extension View {
   /// - Parameter toast: Toaster struct with type, content and duration
   /// - Returns: A view with the toast animated over top
     public func toast(_ toast: Binding<Toaster?>) -> some View {
-        modifier(ToasterModifier(toast: toast))
+      self.modifier(ToasterModifier(toast: toast))
+        .sensoryFeedback(toast)
     }
   
 }

--- a/Sources/Toaster/SwipeToDismiss.swift
+++ b/Sources/Toaster/SwipeToDismiss.swift
@@ -1,0 +1,54 @@
+//
+//  SwipeToDismissModifier.swift
+//  Toaster
+//
+//  Created by Daymein Gregorio on 10/4/25.
+//
+
+import SwiftUI
+
+struct SwipeToDismiss: ViewModifier {
+  @Binding var isPresented: Bool
+
+  @State private var verticalDragAmount: CGFloat = .zero
+  @State private var opacityAmount: CGFloat = 1
+
+  func body(content: Content) -> some View {
+    content
+      .offset(y: verticalDragAmount)
+      .opacity(opacityAmount)
+      .gesture(
+        DragGesture()
+          .onChanged { drag in
+            withAnimation {
+              verticalDragAmount = drag.translation.height
+              if drag.translation.height < 100 {
+                // fade out
+                opacityAmount = (100 - verticalDragAmount) / 100
+              } else {
+                opacityAmount = 0
+              }
+            }
+          }
+          .onEnded { drag in
+            withAnimation {
+              if drag.translation.height > 100 {
+                isPresented = false
+                opacityAmount = 0
+              } else {
+                verticalDragAmount = 0
+                opacityAmount = 1
+              }
+            }
+          }
+      )
+  }
+
+}
+
+extension View {
+
+  func swipeToDismiss(isPresented: Binding<Bool>) -> some View {
+    modifier(SwipeToDismiss(isPresented: isPresented))
+  }
+}

--- a/Sources/Toaster/ToastType.swift
+++ b/Sources/Toaster/ToastType.swift
@@ -67,14 +67,14 @@ extension ToastType {
   }
   
   // TODO: - localization needed
-  /// Title prefix for screen readers.
-  var prefix: String {
+  /// Accessibility label for icon when shown.
+  var accessibilityLabel: String {
     switch self {
-    case .error: return "error,"
-    case .info: return "information,"
-    case .success: return "success,"
-    case .warning: return "warning,"
+    case .error: return "Error"
+    case .info: return "Information"
+    case .success: return "Success"
+    case .warning: return "Warning"
     }
   }
-  
+
 }

--- a/Sources/Toaster/ToasterModifier.swift
+++ b/Sources/Toaster/ToasterModifier.swift
@@ -17,7 +17,6 @@ struct ToasterModifier: ViewModifier {
   
   func body(content: Content) -> some View {
     content
-      .allowsHitTesting(toast == nil)
       .accessibilityHidden(toast != nil)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .overlay(toasterOverlay)
@@ -33,7 +32,7 @@ struct ToasterModifier: ViewModifier {
       if toast != nil {
         Color(.clear)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .disabled(true)
+          .allowsHitTesting(false)
       }
       toasterView()
         .offset(y: -30)
@@ -46,6 +45,7 @@ struct ToasterModifier: ViewModifier {
     if let toast = toast {
       VStack {
         Spacer()
+          .allowsHitTesting(false)
         ToasterView(
           type: toast.type,
           title: toast.title,

--- a/Sources/Toaster/ToasterView.swift
+++ b/Sources/Toaster/ToasterView.swift
@@ -16,10 +16,6 @@ struct ToasterView: View {
   
   var onCancel: (() -> Void)
   
-  var accessibilityTitle: String {
-    "\(type.prefix) \(title)"
-  }
-  
   private var theme: ToasterTheme {
     ToasterTheme(type, colorScheme: colorScheme)
   }
@@ -49,7 +45,7 @@ private extension ToasterView {
   var icon: some View {
     Image(systemName: type.iconSystemName)
       .foregroundColor(theme.accent)
-      .accessibilityHidden(true)
+      .accessibilityLabel(type.accessibilityLabel)
   }
   
   var contentText: some View {
@@ -66,7 +62,6 @@ private extension ToasterView {
       .font(.callout)
       .fontWeight(.medium)
       .foregroundColor(theme.textColor)
-      .accessibilityLabel(accessibilityTitle)
   }
   
   var messageText: some View {
@@ -76,13 +71,15 @@ private extension ToasterView {
   }
   
   var mainContent: some View {
-    HStack(alignment: .top) {
-      icon
-      contentText
-        .accessibilitySortPriority(1)
-      Spacer(minLength: 10)
+    HStack(alignment: .top, spacing: 0) {
+      HStack(alignment: .top, spacing: 0) {
+        icon
+          .padding(.trailing, 4)
+        contentText
+      }
+      .accessibilityElement(children: .combine)
+      .frame(maxWidth: .infinity, alignment: .leading)
       closeButton
-        .accessibilitySortPriority(0)
     }
     .padding([.vertical, .trailing], 8)
     .padding(.leading, 16)
@@ -96,6 +93,7 @@ private extension ToasterView {
       Image(systemName: "xmark")
         .font(.system(size: 12))
         .foregroundColor(theme.textColor)
+        .frame(width: 24, height: 24)
     }
     .accessibilityLabel("close")
   }


### PR DESCRIPTION
This PR sets up Toaster for a 1.0.0 release.

- Updated haptics (iOS 17+)
- Improved a11y conformance
- Swipe to dismiss
- Unblocks UI when toast is present